### PR TITLE
feat: :zap: use launchctl instead of npkill

### DIFF
--- a/FixCore.sh
+++ b/FixCore.sh
@@ -15,10 +15,10 @@ echo "-------"
 echo "Attempting to kill CoreAudio..."
 
 
-sudo pkill coreaudiod
+sudo launchctl kickstart -kp com.apple.audio.coreaudiod
 killStatus=$?
 
-echo "\npkill returned code: " $killStatus "\n"
+echo "\nlaunchctl returned code: " $killStatus "\n"
 
 if [ $killStatus == 1 ] || [ $killStatus == 2 ] || [ $killStatus == 3 ]; then
     echo "😰 Error killing CoreAudio, perhaps you don't have permissions to do so?"


### PR DESCRIPTION
This change provides better compatibility and will actually restart coreaudio properly