### PR TITLE
feat: :sparkles: update `bluetoothd` call to be compatible with 14.4+

### DIFF
--- a/FixCore.sh
+++ b/FixCore.sh
@@ -22,6 +22,7 @@ echo "\n✅ Killed CoreAudio, it should reboot automatically."
 
 echo "\nStep Two: Kill Bluetooth Service (⛔️ WARNING: THIS WILL DISCONNECT ALL BLUETOOTH DEVICES)"
 
-sudo launchctl kickstart -kp system/com.apple.bluetoothd
+sudo killall bluetoothd
+sudo launchctl kickstart -p system/com.apple.bluetoothd
 echo "\n✅ Killed bluetoothd, it should reboot automatically."
 echo "-------"


### PR DESCRIPTION
Turns out the `bluetoothd` daemon behaves similarly to `coreaudiod` on modern versions of macOS and requires a `killall` call instead of using `-kp` on `launchctrl`